### PR TITLE
fix(gitlab): avoid warning if archived is not defined

### DIFF
--- a/src/Gitlab/GitlabProject.php
+++ b/src/Gitlab/GitlabProject.php
@@ -51,7 +51,7 @@ class GitlabProject implements ProjectInterface
 
     public function isArchived(): bool
     {
-        return $this->rawMetadata['archived'];
+        return $this->rawMetadata['archived'] ?? false;
     }
 
     public function getVisibility(): ?ProjectVisibility


### PR DESCRIPTION
(closes #37)