### PR TITLE
fix(gitlab): avoid warning if visibility is not defined

### DIFF
--- a/src/Gitlab/GitlabProject.php
+++ b/src/Gitlab/GitlabProject.php
@@ -56,7 +56,8 @@ class GitlabProject implements ProjectInterface
 
     public function getVisibility(): ?ProjectVisibility
     {
-        switch ($this->rawMetadata['visibility']) {
+        $visibility = $this->rawMetadata['visibility'] ?? 'public';
+        switch ($visibility) {
             case 'public':
                 return ProjectVisibility::PUBLIC;
             case 'private':


### PR DESCRIPTION
(closes #38)