### PR TITLE
Add isEmpty() method to ProjectInterface

### DIFF
--- a/src/Github/GithubProject.php
+++ b/src/Github/GithubProject.php
@@ -59,6 +59,15 @@ class GithubProject implements ProjectInterface
         return $this->rawMetadata['private'] ? ProjectVisibility::PRIVATE : ProjectVisibility::PUBLIC;
     }
 
+    /**
+     * Note that github API doesn't provide an "empty" property, the repository
+     * size (in kB) is used to detect repositories without content.
+     */
+    public function isEmpty(): bool
+    {
+        return 0 === ($this->rawMetadata['size'] ?? 0);
+    }
+
     public function getRawMetadata(): array
     {
         return $this->rawMetadata;

--- a/src/Gitlab/GitlabProject.php
+++ b/src/Gitlab/GitlabProject.php
@@ -74,6 +74,11 @@ class GitlabProject implements ProjectInterface
         }
     }
 
+    public function isEmpty(): bool
+    {
+        return $this->rawMetadata['empty_repo'] ?? false;
+    }
+
     public function getRawMetadata(): array
     {
         return $this->rawMetadata;

--- a/src/Gogs/GogsProject.php
+++ b/src/Gogs/GogsProject.php
@@ -65,6 +65,11 @@ class GogsProject implements ProjectInterface
         return ProjectVisibility::PUBLIC;
     }
 
+    public function isEmpty(): bool
+    {
+        return $this->rawMetadata['empty'] ?? false;
+    }
+
     public function getRawMetadata(): array
     {
         return $this->rawMetadata;

--- a/src/ProjectInterface.php
+++ b/src/ProjectInterface.php
@@ -52,6 +52,11 @@ interface ProjectInterface
     public function getVisibility(): ?ProjectVisibility;
 
     /**
+     * Indicates if the repository is empty.
+     */
+    public function isEmpty(): bool;
+
+    /**
      * Get hosting service specific properties.
      *
      * @return array<string,mixed>

--- a/tests/Github/GithubProjectTest.php
+++ b/tests/Github/GithubProjectTest.php
@@ -88,6 +88,28 @@ class GithubProjectTest extends TestCase
         $this->assertEquals(ProjectVisibility::PUBLIC, $this->project->getVisibility());
     }
 
+    public function testIsEmpty(): void
+    {
+        $this->assertFalse($this->project->isEmpty());
+    }
+
+    public function testIsEmptyWithoutContent(): void
+    {
+        $project = new GithubProject([
+            'id' => '12345',
+            'size' => 0,
+        ]);
+        $this->assertTrue($project->isEmpty());
+    }
+
+    public function testIsEmptyUndefined(): void
+    {
+        $project = new GithubProject([
+            'id' => '12345',
+        ]);
+        $this->assertTrue($project->isEmpty());
+    }
+
     public function testGetRawMetadata(): void
     {
         $metadata = $this->project->getRawMetadata();

--- a/tests/Gitlab/GitlabProjectTest.php
+++ b/tests/Gitlab/GitlabProjectTest.php
@@ -64,6 +64,28 @@ class GitlabProjectTest extends TestCase
         $this->assertEquals(ProjectVisibility::PUBLIC, $this->project->getVisibility());
     }
 
+    public function testIsEmpty(): void
+    {
+        $this->assertFalse($this->project->isEmpty());
+    }
+
+    public function testIsEmptyWithEmptyRepo(): void
+    {
+        $project = new GitlabProject([
+            'id' => '12345',
+            'empty_repo' => true,
+        ]);
+        $this->assertTrue($project->isEmpty());
+    }
+
+    public function testIsEmptyUndefined(): void
+    {
+        $project = new GitlabProject([
+            'id' => '12345',
+        ]);
+        $this->assertFalse($project->isEmpty());
+    }
+
     public function testGetRawMetadata(): void
     {
         $metadata = $this->project->getRawMetadata();

--- a/tests/Gogs/GiteaProjectTest.php
+++ b/tests/Gogs/GiteaProjectTest.php
@@ -65,6 +65,28 @@ class GiteaProjectTest extends TestCase
         $this->assertEquals(ProjectVisibility::PUBLIC, $this->project->getVisibility());
     }
 
+    public function testIsEmpty(): void
+    {
+        $this->assertFalse($this->project->isEmpty());
+    }
+
+    public function testIsEmptyWithEmptyRepo(): void
+    {
+        $project = new GogsProject([
+            'id' => '12345',
+            'empty' => true,
+        ]);
+        $this->assertTrue($project->isEmpty());
+    }
+
+    public function testIsEmptyUndefined(): void
+    {
+        $project = new GogsProject([
+            'id' => '12345',
+        ]);
+        $this->assertFalse($project->isEmpty());
+    }
+
     public function testGetRawMetadata(): void
     {
         $metadata = $this->project->getRawMetadata();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -55,6 +55,8 @@ class TestCase extends BaseTestCase
         $this->assertNotEmpty($project->getName());
         // should not crash (can be null or empty)
         $project->getDefaultBranch();
+        // no empty repositories in functional tests cases
+        $this->assertFalse($project->isEmpty());
         $this->assertNotEmpty($project->getHttpUrl());
         $this->assertNotEmpty($project->getRawMetadata());
     }


### PR DESCRIPTION
This pull request adds a new `isEmpty()` method to the `ProjectInterface` and implements it for GitHub, GitLab, and Gogs/Gitea project classes. The method provides a unified way to check if a repository is empty, using the most appropriate metadata field for each provider. Comprehensive tests are also added for each implementation.

### Interface and Implementation Changes

* Added `isEmpty()` method to `ProjectInterface` to standardize how repository emptiness is detected across different providers.
* Implemented the `isEmpty()` method in `GithubProject`, using the `size` field to determine emptiness, since GitHub does not provide a direct "empty" property.
* Implemented the `isEmpty()` method in `GitlabProject`, using the `empty_repo` field.
* Implemented the `isEmpty()` method in `GogsProject`, using the `empty` field.

### Testing

* Added and extended tests for the new `isEmpty()` method in `GithubProjectTest`, `GitlabProjectTest`, and `GiteaProjectTest` to cover various cases, including when the repository is empty, not empty, or the relevant field is undefined. [[1]](diffhunk://#diff-825261b4ac2a13d242629276e6bdb4643be97b455dfcb9e4ac576b5decf4a042R91-R112) [[2]](diffhunk://#diff-460799372e20a31a92e55666f9d143718e511fdbf783a6263bd64f7fb7e795d7R67-R88) [[3]](diffhunk://#diff-0967c7fa02ccf69263a950dd2bbf47e6255a2e7972ac21f5dbf276575e4b4569R68-R89)
* Updated the base test case to assert that repositories used in functional tests are not empty.

(closes #51)
