### PR TITLE
Add isEmpty() to ClientInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A lightweight PHP client providing a consistent access to hosted and self-hosted
     * usernames
     * organizations/groups
 * Get raw files from repositories
+* Detect empty repositories (`isEmpty`)
 * Apply custom filter
     * Project contains a given file (`RequiredFileFilter`)
     * Project is a composer project (`ComposerProjectFilter`)
@@ -95,6 +96,22 @@ $filterCollection->addFilter(new RequiredFileFilter(
 $options->setFilter($filterCollection);
 $projects = $client->find($options);
 ```
+
+### Skip empty repositories
+
+```php
+$options = new FindOptions();
+$options->setUsers(array('mborne'));
+foreach ($client->getProjects($options) as $project) {
+    // avoid attempting cloning empty repositories
+    if ($client->isEmpty($project)) {
+        continue;
+    }
+    // ...
+}
+```
+
+Note that `isEmpty` relies on the project metadata for gitlab (`empty_repo`), gitea and gogs (`empty`). As the github API doesn't provide such property, an extra API call is performed for repositories reported with a size of 0 (the size is expressed in kB and rounded, so that a repository containing a single small file is also reported with a size of 0).
 
 ## Dependencies
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -27,6 +27,14 @@ interface ClientInterface
     public function find(FindOptions $options): array;
 
     /**
+     * Indicates if the repository is empty (no commit).
+     *
+     * Note that an API call may be performed as some hosts don't provide this
+     * information in the project metadata.
+     */
+    public function isEmpty(ProjectInterface $project): bool;
+
+    /**
      * Get raw file.
      *
      * @param ProjectInterface $project  ex : 123456

--- a/src/Github/GithubClient.php
+++ b/src/Github/GithubClient.php
@@ -11,6 +11,7 @@ use MBO\RemoteGit\Http\TokenType;
 use MBO\RemoteGit\ProjectFilterInterface;
 use MBO\RemoteGit\ProjectInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Client implementation for github.
@@ -109,6 +110,41 @@ class GithubClient extends AbstractClient
             '/orgs/'.$org.'/repos',
             $projectFilter
         );
+    }
+
+    public function isEmpty(ProjectInterface $project): bool
+    {
+        $metadata = $project->getRawMetadata();
+
+        /*
+         * github API doesn't provide an "empty" property. The repository size is
+         * expressed in kB and rounded, so that a size of 0 doesn't mean that the
+         * repository is empty (ex : a repository containing a small README.md).
+         */
+        if (0 !== ($metadata['size'] ?? 0)) {
+            return false;
+        }
+
+        /*
+         * Ensure that there is no commit, github replying
+         * "409 Git Repository is empty." for empty repositories.
+         *
+         * @see https://docs.github.com/en/rest/commits/commits#list-commits
+         */
+        $uri = str_replace('{/sha}', '', $metadata['commits_url']).'?per_page=1';
+        $this->getLogger()->debug('GET '.$uri);
+        $response = $this->getHttpClient()->request('GET', $uri, [
+            'http_errors' => false,
+        ]);
+        $statusCode = $response->getStatusCode();
+        switch ($statusCode) {
+            case 409:
+                return true;
+            case 200:
+                return false;
+            default:
+                throw new RuntimeException("Unexpected status code $statusCode for GET $uri");
+        }
     }
 
     public function getRawFile(

--- a/src/Gitlab/GitlabClient.php
+++ b/src/Gitlab/GitlabClient.php
@@ -113,6 +113,12 @@ class GitlabClient extends AbstractClient
         );
     }
 
+    public function isEmpty(ProjectInterface $project): bool
+    {
+        // ref : https://docs.gitlab.com/api/projects/#list-all-projects
+        return $project->getRawMetadata()['empty_repo'] ?? false;
+    }
+
     public function getRawFile(
         ProjectInterface $project,
         string $filePath,

--- a/src/Gogs/GogsClient.php
+++ b/src/Gogs/GogsClient.php
@@ -100,6 +100,12 @@ class GogsClient extends AbstractClient
         );
     }
 
+    public function isEmpty(ProjectInterface $project): bool
+    {
+        // ref : https://docs.gitea.com/api/1.20/#tag/repository/operation/repoGet
+        return $project->getRawMetadata()['empty'] ?? false;
+    }
+
     public function getRawFile(
         ProjectInterface $project,
         $filePath,

--- a/tests/Github/GithubClientFunctionalTest.php
+++ b/tests/Github/GithubClientFunctionalTest.php
@@ -104,6 +104,9 @@ class GithubClientFunctionalTest extends TestCase
         /* test isArchived */
         $this->assertFalse($project->isArchived());
 
+        /* test isEmpty */
+        $this->assertFalse($client->isEmpty($project));
+
         /* test getVisibility */
         $this->assertEquals(ProjectVisibility::PUBLIC, $project->getVisibility());
     }

--- a/tests/Github/GithubClientTest.php
+++ b/tests/Github/GithubClientTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace MBO\RemoteGit\Tests\Github;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use MBO\RemoteGit\Github\GithubClient;
+use MBO\RemoteGit\Github\GithubProject;
+use MBO\RemoteGit\Tests\TestCase;
+
+/**
+ * Test GithubClient with mocked HTTP responses.
+ */
+class GithubClientTest extends TestCase
+{
+    private MockHandler $mockHandler;
+
+    /**
+     * Create a client with a queue of mocked responses.
+     *
+     * @param Response[] $responses
+     */
+    private function createGithubClient(array $responses = []): GithubClient
+    {
+        $this->mockHandler = new MockHandler($responses);
+
+        return new GithubClient(new GuzzleHttpClient([
+            'base_uri' => 'https://api.github.com',
+            'handler' => HandlerStack::create($this->mockHandler),
+        ]));
+    }
+
+    /**
+     * Get the URI requested by the client, null if no request is performed.
+     */
+    private function getLastRequestUri(): ?string
+    {
+        $request = $this->mockHandler->getLastRequest();
+
+        return null === $request ? null : (string) $request->getUri();
+    }
+
+    /**
+     * Create a project reported with a size of 0 by github API.
+     */
+    private function createEmptySizedProject(): GithubProject
+    {
+        return new GithubProject([
+            'id' => '12345',
+            'full_name' => 'mborne/sample-empty',
+            'commits_url' => 'https://api.github.com/repos/mborne/sample-empty/commits{/sha}',
+            'size' => 0,
+        ]);
+    }
+
+    /**
+     * A repository with a size is not empty, no API call required.
+     */
+    public function testIsEmptyWithContent(): void
+    {
+        $client = $this->createGithubClient();
+        $project = new GithubProject($this->getDataJson('github/docker-devbox.json'));
+
+        $this->assertFalse($client->isEmpty($project));
+        $this->assertNull($this->getLastRequestUri());
+    }
+
+    /**
+     * github replies "409 Git Repository is empty." when there is no commit.
+     */
+    public function testIsEmptyWithoutCommit(): void
+    {
+        $client = $this->createGithubClient([
+            new Response(409, [], (string) json_encode([
+                'message' => 'Git Repository is empty.',
+            ])),
+        ]);
+
+        $this->assertTrue($client->isEmpty($this->createEmptySizedProject()));
+        $this->assertEquals(
+            'https://api.github.com/repos/mborne/sample-empty/commits?per_page=1',
+            $this->getLastRequestUri()
+        );
+    }
+
+    /**
+     * A repository smaller than 1 kB is reported with a size of 0 by github
+     * while it contains commits.
+     */
+    public function testIsEmptyWithSmallContent(): void
+    {
+        $client = $this->createGithubClient([
+            new Response(200, [], (string) json_encode([
+                ['sha' => '5d4f2c1b'],
+            ])),
+        ]);
+
+        $this->assertFalse($client->isEmpty($this->createEmptySizedProject()));
+        $this->assertEquals(
+            'https://api.github.com/repos/mborne/sample-empty/commits?per_page=1',
+            $this->getLastRequestUri()
+        );
+    }
+
+    public function testIsEmptyWithUnexpectedStatusCode(): void
+    {
+        $client = $this->createGithubClient([
+            new Response(404, [], (string) json_encode([
+                'message' => 'Not Found',
+            ])),
+        ]);
+
+        $thrown = null;
+        try {
+            $client->isEmpty($this->createEmptySizedProject());
+        } catch (\Exception $e) {
+            $thrown = $e;
+        }
+        $this->assertNotNull($thrown, 'exception should be thrown');
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        $this->assertEquals(
+            'Unexpected status code 404 for GET https://api.github.com/repos/mborne/sample-empty/commits?per_page=1',
+            $thrown->getMessage()
+        );
+    }
+}

--- a/tests/Gitlab/GitlabClientFunctionalTest.php
+++ b/tests/Gitlab/GitlabClientFunctionalTest.php
@@ -86,6 +86,9 @@ class GitlabClientFunctionalTest extends TestCase
         /* test isArchived */
         $this->assertFalse($project->isArchived());
 
+        /* test isEmpty */
+        $this->assertFalse($client->isEmpty($project));
+
         /* test getVisibility */
         $this->assertEquals(ProjectVisibility::PUBLIC, $project->getVisibility());
     }
@@ -155,6 +158,9 @@ class GitlabClientFunctionalTest extends TestCase
 
         /* test isArchived */
         $this->assertFalse($project->isArchived());
+
+        /* test isEmpty */
+        $this->assertFalse($client->isEmpty($project));
 
         /* test getVisibility */
         $this->assertEquals(ProjectVisibility::PUBLIC, $project->getVisibility());

--- a/tests/Gitlab/GitlabClientTest.php
+++ b/tests/Gitlab/GitlabClientTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MBO\RemoteGit\Tests\Gitlab;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use MBO\RemoteGit\Gitlab\GitlabClient;
+use MBO\RemoteGit\Gitlab\GitlabProject;
+use MBO\RemoteGit\Tests\TestCase;
+
+/**
+ * Test GitlabClient without API call, gitlab providing "empty_repo"
+ * in the project metadata.
+ */
+class GitlabClientTest extends TestCase
+{
+    /**
+     * Create a client which fails if an API call is performed.
+     */
+    private function createGitlabClient(): GitlabClient
+    {
+        return new GitlabClient(new GuzzleHttpClient([
+            'base_uri' => 'https://gitlab.com',
+            'handler' => HandlerStack::create(new MockHandler()),
+        ]));
+    }
+
+    public function testIsEmptyWithContent(): void
+    {
+        $client = $this->createGitlabClient();
+        $project = new GitlabProject($this->getDataJson('gitlab/sample-composer.json'));
+
+        $this->assertFalse($client->isEmpty($project));
+    }
+
+    public function testIsEmptyWithEmptyRepo(): void
+    {
+        $client = $this->createGitlabClient();
+        $project = new GitlabProject([
+            'id' => '12345',
+            'empty_repo' => true,
+        ]);
+
+        $this->assertTrue($client->isEmpty($project));
+    }
+
+    public function testIsEmptyUndefined(): void
+    {
+        $client = $this->createGitlabClient();
+        $project = new GitlabProject([
+            'id' => '12345',
+        ]);
+
+        $this->assertFalse($client->isEmpty($project));
+    }
+}

--- a/tests/Gogs/GiteaClientFunctionalTest.php
+++ b/tests/Gogs/GiteaClientFunctionalTest.php
@@ -79,6 +79,9 @@ class GiteaClientFunctionalTest extends TestCase
         /* test isArchived */
         $this->assertFalse($project->isArchived());
 
+        /* test isEmpty */
+        $this->assertFalse($client->isEmpty($project));
+
         /* test getVisibility */
         $this->assertEquals(ProjectVisibility::PUBLIC, $project->getVisibility());
 

--- a/tests/Gogs/GiteaClientTest.php
+++ b/tests/Gogs/GiteaClientTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MBO\RemoteGit\Tests\Gogs;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use MBO\RemoteGit\Gogs\GogsClient;
+use MBO\RemoteGit\Gogs\GogsProject;
+use MBO\RemoteGit\Tests\TestCase;
+
+/**
+ * Test GogsClient without API call, gitea and gogs providing "empty"
+ * in the project metadata.
+ */
+class GiteaClientTest extends TestCase
+{
+    /**
+     * Create a client which fails if an API call is performed.
+     */
+    private function createGogsClient(): GogsClient
+    {
+        return new GogsClient(new GuzzleHttpClient([
+            'base_uri' => 'https://gitea.com',
+            'handler' => HandlerStack::create(new MockHandler()),
+        ]));
+    }
+
+    public function testIsEmptyWithContent(): void
+    {
+        $client = $this->createGogsClient();
+        $project = new GogsProject($this->getDataJson('gitea/sample-composer.json'));
+
+        $this->assertFalse($client->isEmpty($project));
+    }
+
+    public function testIsEmptyWithEmptyRepo(): void
+    {
+        $client = $this->createGogsClient();
+        $project = new GogsProject([
+            'id' => '12345',
+            'empty' => true,
+        ]);
+
+        $this->assertTrue($client->isEmpty($project));
+    }
+
+    public function testIsEmptyUndefined(): void
+    {
+        $client = $this->createGogsClient();
+        $project = new GogsProject([
+            'id' => '12345',
+        ]);
+
+        $this->assertFalse($client->isEmpty($project));
+    }
+}


### PR DESCRIPTION
Adds `isEmpty(ProjectInterface $project): bool` to `ClientInterface`, replacing the `ProjectInterface` approach of #52 which can't be reliable on github.

Motivation : avoid attempting cloning empty repositories.

## Implementation

| Client | Detection | API call |
| --- | --- | --- |
| `GitlabClient` | `empty_repo` from the project metadata | no |
| `GogsClient` | `empty` from the project metadata | no |
| `GithubClient` | `size !== 0` means "not empty", otherwise a request on the commits confirms it | only when `size === 0` |

github doesn't provide an "empty" property and its `size` is expressed in kB and rounded, so a size of 0 doesn't mean that the repository is empty (see #52). `GithubClient::isEmpty()` confirms it with `GET {commits_url}?per_page=1` :

* `409` (`Git Repository is empty.`) : empty
* `200` : not empty
* anything else : `RuntimeException`

The URI is derived from the `commits_url` property, as `getRawFile()` already does with `contents_url`. `http_errors` is disabled for this request to avoid driving the flow with exceptions.

Checked against the `IGNF` organization : 198 projects, 3 reported as empty (`geoportal-extensions-leaflet`, `poc_oracle`, `Geodesie-web`), all three confirmed by `GET /commits`. `IGNF/obligations-legales-debroussaillement` - the false positive of #52, a single commit with a 171 bytes `README.md` reported with `size: 0` - is no longer reported as empty. Only 4 extra API calls were performed for these 198 projects.

## Tests

New offline tests relying on guzzle `MockHandler` :

* `GithubClientTest` : content (no HTTP request performed), `409` (empty), `200` on a repository with `size: 0` (not empty), unexpected status code (exception). The requested URI is checked to cover the `{/sha}` substitution.
* `GitlabClientTest` and `GiteaClientTest` : `empty_repo`/`empty` set, unset or missing, with an empty mock queue so that any API call would fail the test.

`assertFalse($client->isEmpty($project))` has also been added next to the existing `isArchived()` assertions of the functional tests. Note that `TestCase::assertGettersWorks()` can't assert anything here, as `gitlab-org` (~35 projects) and `IGNF` (3 projects) do contain empty repositories.

`composer test` : 65 tests, 3035 assertions, php-cs-fixer and phpstan (level 8) clean.

## Breaking change

Adding a method to `ClientInterface` breaks external implementations of this interface.

closes #53
